### PR TITLE
Manifest header wrong comparation between two unsigned values

### DIFF
--- a/core/manifest/manifest_flash.c
+++ b/core/manifest/manifest_flash.c
@@ -143,7 +143,7 @@ int manifest_flash_read_header (struct manifest_flash *manifest, struct manifest
 		return MANIFEST_BAD_MAGIC_NUMBER;
 	}
 
-	if (header->sig_length > (header->length - sizeof (struct manifest_header))) {
+	if ((int)header->sig_length > (int)(header->length - sizeof (struct manifest_header))) {
 		return MANIFEST_BAD_LENGTH;
 	}
 


### PR DESCRIPTION
This is a vulnerability in the manifest_flash.c header parse calculations. 
Corrupted manifest header results in DOS or much severe implications that might end with a possible RCE.
E.g. Manifest header with length=0 cause the code to read the whole flash until crash. After updating a manifest with such malformed header, the system could be bricked.

Thus fix the comparation between two unsigned values for detecting a negative value.