### PR TITLE
Flash: Handle 4B only flashes and flash reset.

### DIFF
--- a/core/flash/spi_flash.c
+++ b/core/flash/spi_flash.c
@@ -192,7 +192,7 @@ static int spi_flash_configure_device (const struct spi_flash *flash, bool wake_
 
 	if (reset_device) {
 		status = spi_flash_reset_device (flash);
-		if (status != 0) {
+		if ((status != 0) && (status != SPI_FLASH_RESET_NOT_SUPPORTED)) {
 			goto exit;
 		}
 	}

--- a/core/flash/spi_flash_sfdp.c
+++ b/core/flash/spi_flash_sfdp.c
@@ -601,7 +601,13 @@ int spi_flash_sfdp_get_4byte_mode_switch (const struct spi_flash_sfdp_basic_tabl
 
 	params = (struct spi_flash_sfdp_basic_parameter_table_1_5*) table->data;
 	if (table->sfdp->sfdp_header.parameter0.minor_revision >= 5) {
-		if ((params->enter_4b & 0x7f) == 0) {
+
+		// 4 bytes only flash, no switch command available:
+		if ((params->table_1_0.dspi_qspi & SPI_FLASH_SFDP_ADDRESS_BYTES) ==
+			SPI_FLASH_SFDP_4BYTE_ONLY) {
+			*addr_4byte = SPI_FLASH_SFDP_4BYTE_MODE_FIXED;
+		}
+		else if ((params->enter_4b & 0x7f) == 0) {
 			*addr_4byte = SPI_FLASH_SFDP_4BYTE_MODE_UNSUPPORTED;
 		}
 		else if ((params->enter_4b & SPI_FLASH_SFDP_4B_ENTER_B7) &&


### PR DESCRIPTION
Flash 4B address mode only. Add support for flashes that are in 4B address mode only
             there is no command to switch 4B mode on and off.

Flash reset: Some flashes don't support reset command.
             If the app calls spi_flash_initialize_device it
             does not know it in advance and it may ask to reset the device. If reset is not supported by the flash
             spi_flash_initialize_device should still continue in this case and not fail the flash init.