### PR TITLE
mctp control message: revise completion code.

### DIFF
--- a/core/mctp/mctp_control_protocol.h
+++ b/core/mctp/mctp_control_protocol.h
@@ -55,11 +55,11 @@ enum
 {
 	MCTP_CONTROL_PROTOCOL_SUCCESS,							/**< Success */
 	MCTP_CONTROL_PROTOCOL_ERROR,							/**< Generic error */
-	MCTP_CONTROL_PROTOCOL_ERROR_INVALID_DATA = 0x03,		/**< Invalid data or parameter value */
+	MCTP_CONTROL_PROTOCOL_ERROR_INVALID_DATA,		/**< Invalid data or parameter value */
 	MCTP_CONTROL_PROTOCOL_ERROR_INVALID_LEN,				/**< Invalid message length */
-	MCTP_CONTROL_PROTOCOL_ERROR_NOT_READY = 0xF0,			/**< Receiver not ready */
+	MCTP_CONTROL_PROTOCOL_ERROR_NOT_READY,			/**< Receiver not ready */
 	MCTP_CONTROL_PROTOCOL_ERROR_UNSUPPORTED_CMD,			/**< Command unspecified or unsupported */
-	MCTP_CONTROL_PROTOCOL_CMD_SPECIFIC,						/**< Command specific completion code */
+	MCTP_CONTROL_PROTOCOL_CMD_SPECIFIC = 0x80,						/**< Command specific completion code */
 };
 
 


### PR DESCRIPTION
According to the DSP0236 v1.3.1 Table 13, revises the MCTP control message completion code as following.

SUCCESS 0x00
ERROR 0x01
ERROR_INVALID_DATA 0x02
ERROR_INVALID_LENGTH 0x03
ERROR_NOT_READY 0x04
ERROR_UNSUPPORTED_CMD 0x05
COMMAND_SPECIFIC 0x80

Signed-off-by: Jamin Lin <jamin_lin@aspeedtech.com>